### PR TITLE
add param to fetchEventSource to keep the request open while a tab is…

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -73,6 +73,7 @@ export default function Home() {
           history,
         }),
         signal: ctrl.signal,
+        openWhenHidden: true, // allow the request to continue when the tab is hidden
         onmessage: (event) => {
           if (event.data === '[DONE]') {
             setMessageState((state) => ({


### PR DESCRIPTION
… hidden. Should prevent duplicate request if a user tab thrashes on a long chain request